### PR TITLE
Authentication and additional config entries for private GitLabs

### DIFF
--- a/bin/satis-gitlab
+++ b/bin/satis-gitlab
@@ -7,7 +7,5 @@ require_once dirname(__FILE__).'/../vendor/autoload.php';
  */
 $application = new Composer\Satis\Console\Application();
 $application->add(new \MBO\SatisGitlab\Command\GitlabToConfigCommand());
+$application->add(new \MBO\SatisGitlab\Command\AuthConfigCommand());
 $application->run();
-
-
-

--- a/src/MBO/SatisGitlab/Command/AuthConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/AuthConfigCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MBO\SatisGitlab\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Generates auth configuration for gitlab repositories
+ *
+ * @author Dmytro Naumenko <d.naumenko.a@gmail.com>
+ */
+class AuthConfigCommand extends Command {
+    protected function configure() {
+        $this
+            ->setName('auth-config')
+
+            // the short description shown while running "php bin/console list"
+            ->setDescription('generate authentication configuration for GitLab')
+            ->addArgument('gitlab-url', InputArgument::REQUIRED)
+            ->addArgument('gitlab-token')
+
+            ->addOption('output', 'O', InputOption::VALUE_REQUIRED, 'output auth config file', 'auth.json')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) {
+        $gitlabUrl = $input->getArgument('gitlab-url');
+        $gitlabAuthToken = $input->getArgument('gitlab-token');
+        $outputFile = $input->getOption('output');
+
+        $gitlabDomain = parse_url($gitlabUrl, PHP_URL_HOST);
+
+        $config = array();
+        $config['gitlab-domains'] = array($gitlabDomain);
+        $config['gitlab-token'][$gitlabDomain] = $gitlabAuthToken;
+
+        $result = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        file_put_contents($outputFile, $result);
+    }
+}

--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -114,6 +114,7 @@ class GitlabToConfigCommand extends Command {
         }
 
         if ($additionalConfigFile) {
+            $output->writeln("<info>Applying additional config from $additionalConfigFile</info>");
             $satis = $this->mergeWithAdditionalConfig($additionalConfigFile, $satis);
         }
 

--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -2,6 +2,8 @@
 
 namespace MBO\SatisGitlab\Command;
 
+use Composer\Composer;
+use Composer\Config;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,6 +34,7 @@ class GitlabToConfigCommand extends Command {
             ->addOption('output', 'O', InputOption::VALUE_REQUIRED, 'output config file', 'satis.json')
             ->addOption('homepage', null, InputOption::VALUE_REQUIRED, 'satis homepage', 'http://satis.example.org/satis/')
             ->addOption('archive', null, InputOption::VALUE_NONE, 'enable archive mirroring')
+            ->addOption('additional-config', null, InputOption::VALUE_OPTIONAL, 'Config prototype, that will be added to the generated config')
         ;
     }
 
@@ -42,6 +45,7 @@ class GitlabToConfigCommand extends Command {
         $gitlabUrl = $input->getArgument('gitlab-url');
         $gitlabAuthToken = $input->getArgument('gitlab-token');
         $outputFile = $input->getOption('output');
+        $additionalConfigFile = $input->getOption('additional-config');
         $homepage = $input->getOption('homepage');
         
         /*
@@ -64,7 +68,7 @@ class GitlabToConfigCommand extends Command {
                 'directory' => 'dist',
                 'format' => 'tar',
                 'skip-dev' => true
-            );            
+            );
         }
 
         $client = $this->createGitlabClient($gitlabUrl, $gitlabAuthToken);
@@ -107,6 +111,10 @@ class GitlabToConfigCommand extends Command {
                     );
                 }
             }
+        }
+
+        if ($additionalConfigFile) {
+            $satis = $this->mergeWithAdditionalConfig($additionalConfigFile, $satis);
         }
 
         $output->writeln("<info>generate satis configuration file : $outputFile</info>");
@@ -161,4 +169,18 @@ class GitlabToConfigCommand extends Command {
         return $client;
     }
 
+    /**
+     * Recursively merges $satis config with config from $additionalConfigFile
+     *
+     * @param string $additionalConfigFile
+     * @param array $satis
+     * @return array
+     */
+    protected function mergeWithAdditionalConfig($additionalConfigFile, $satis)
+    {
+        $fileContent = file_get_contents($additionalConfigFile);
+        $config = json_decode($fileContent, true);
+
+        return array_merge_recursive($satis, $config);
+    }
 }


### PR DESCRIPTION
Hello.
Thank you for a good project. Let me submit the very first PR in it :)

This PR contains 2 enhancements:

1. Adds `auth-config` command, that can be used to generate authentication config to make Composer access private repositories in GitLab.
2. Adds `additional-config` option to `GitlabToConfigCommand` making possible to add some entries to resulting satis.json file. The use case is an additional repository that is required by packages, found in GitLab. In my case it is https://asset-packagist.org/ for Bower and NPM assets.

Thank you