### PR TITLE
Allow population gitlab public repositories without an auth Token.

### DIFF
--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -89,7 +89,7 @@ class GitlabToConfigCommand extends Command {
             $satis['config']['gitlab-domains'][] = $gitlabDomain ;
         }
 
-        if ( ! $input->getOption('no-token') ){
+        if ( ! $input->getOption('no-token') && ! empty($gitlabAuthToken) ){
             if ( ! isset($satis['config']['gitlab-token']) ){
                 $satis['config']['gitlab-token'] = array();
             }
@@ -188,12 +188,12 @@ class GitlabToConfigCommand extends Command {
         $client = new \Gitlab\Client($httpClientBuilder);
         $client->setUrl($gitlabUrl);
 
-        /*
-         * gitlab authentification
-         */
-        $client
-            ->authenticate($gitlabAuthToken, \Gitlab\Client::AUTH_URL_TOKEN)
-        ;
+        // Authenticate to gitlab, if a token is provided
+        if ( ! empty($gitlabAuthToken) ) {
+            $client
+                ->authenticate($gitlabAuthToken, \Gitlab\Client::AUTH_URL_TOKEN)
+            ;
+        }
         
         return $client;
     }


### PR DESCRIPTION
We wanted to setup a repository of the libraries and components we have built without listing all the projects we have access to.

The Gitlab api does not require an auth token in order to make request. Having this be an optional argument during setup would make the library easier to setup if the token is not required.