### PR TITLE
Export satis-gitlab into project bin folder.

### DIFF
--- a/bin/satis-gitlab
+++ b/bin/satis-gitlab
@@ -1,6 +1,26 @@
 #!/usr/bin/php
 <?php
-require_once dirname(__FILE__).'/../vendor/autoload.php';
+
+/*
+ * This file is part of mbo/satis-gitlab.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+function includeIfExists($file)
+{
+    if (file_exists($file)) {
+        return include $file;
+    }
+}
+
+if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
+    print('You must set up the project dependencies using Composer before you can use Satis.');
+    exit(1);
+}
 
 /*
  * create extended satis application

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
     "autoload": {
         "psr-4": {"": "src/"}
     },
+    "bin": [
+        "bin/satis-gitlab"
+    ],
     "require": {
         "m4tthumphrey/php-gitlab-api": "^9.6",
         "php-http/guzzle6-adapter": "^1.1",


### PR DESCRIPTION
We are running this as a dependency inside another project, which results in different paths for the vendor folder.

Exporting the `satis-gitlab` executable into the parent projects configured bin folder, allows the usage of the command to be cleaner. This requires using a dynamic import of the composer autoload. I used the same logic as the [Satis command's import](https://github.com/composer/satis/blob/a3751aa1bbcabc815fe02e6c458c654ab2d827f6/bin/satis#L13) for constancy.