### PR TITLE
Make the homepage arguement optional

### DIFF
--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -19,6 +19,8 @@ class GitlabToConfigCommand extends Command {
 
     const PER_PAGE = 50;
     const MAX_PAGES = 10000;
+    const HOMEPAGE_DEFAULT = '_default_';
+    const HOMEPAGE_DEFAULT_VALUE = 'http://localhost/satis/';
 
     protected function configure() {
         $templatePath = realpath( dirname(__FILE__).'/../Resources/default-template.json' );
@@ -65,7 +67,13 @@ class GitlabToConfigCommand extends Command {
         /*
          * customize according to command line options
          */
-        $satis['homepage'] = $input->getOption('homepage');
+        $homepage = $input->getOption('homepage');
+        $homepage_default = $homepage === static::HOMEPAGE_DEFAULT;
+        $homepage_empty = !isset($satis['homepage']);
+        if ( ! $homepage_default || $homepage_empty ) {
+          $satis['homepage'] = ($homepage_default) ? static::HOMEPAGE_DEFAULT_VALUE : $homepage;
+        }
+
         // mirroring
         if ( $input->getOption('archive') ){
             $satis['require-dependencies'] = true;

--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -24,7 +24,7 @@ class GitlabToConfigCommand extends Command {
 
     protected function configure() {
         $templatePath = realpath( dirname(__FILE__).'/../Resources/default-template.json' );
-        
+
         $this
             // the name of the command (the part after "bin/console")
             ->setName('gitlab-to-config')
@@ -34,7 +34,7 @@ class GitlabToConfigCommand extends Command {
             ->setHelp('look for composer.json in default gitlab branche, extract project name and register them in SATIS configuration')
             ->addArgument('gitlab-url', InputArgument::REQUIRED)
             ->addArgument('gitlab-token')
-            
+
             // deep customization : template file extended with default configuration
             ->addOption('template', null, InputOption::VALUE_REQUIRED, 'template satis.json extended with gitlab repositories', $templatePath)
 
@@ -45,7 +45,7 @@ class GitlabToConfigCommand extends Command {
             ->addOption('no-token', null, InputOption::VALUE_NONE, 'disable token writing in output configuration')
 
             // output configuration
-            ->addOption('output', 'O', InputOption::VALUE_REQUIRED, 'output config file', 'satis.json')     
+            ->addOption('output', 'O', InputOption::VALUE_REQUIRED, 'output config file', 'satis.json')
         ;
     }
 
@@ -63,7 +63,7 @@ class GitlabToConfigCommand extends Command {
         $templatePath = $input->getOption('template');
         $output->writeln(sprintf("<info>Loading template %s...</info>", $templatePath));
         $satis = json_decode( file_get_contents($templatePath), true) ;
-        
+
         /*
          * customize according to command line options
          */
@@ -111,7 +111,7 @@ class GitlabToConfigCommand extends Command {
         $client = $this->createGitlabClient($gitlabUrl, $gitlabAuthToken);
         for ($page = 1; $page <= self::MAX_PAGES; $page++) {
             $projects = $client->projects()->all(array(
-                'page' => $page, 
+                'page' => $page,
                 'per_page' => self::PER_PAGE
             ));
             if ( empty($projects) ){
@@ -163,8 +163,8 @@ class GitlabToConfigCommand extends Command {
      * display project information
      */
     protected function displayProjectInfo(
-        OutputInterface $output, 
-        array $project, 
+        OutputInterface $output,
+        array $project,
         $message,
         $verbosity = OutputInterface::VERBOSITY_NORMAL
     ){
@@ -175,8 +175,8 @@ class GitlabToConfigCommand extends Command {
             $message
         ),$verbosity);
     }
-    
-    
+
+
     /**
      * Create gitlab client
      * @param string $gitlabUrl
@@ -202,7 +202,7 @@ class GitlabToConfigCommand extends Command {
                 ->authenticate($gitlabAuthToken, \Gitlab\Client::AUTH_URL_TOKEN)
             ;
         }
-        
+
         return $client;
     }
 


### PR DESCRIPTION
The `--homepage` option on the `gitlab-to-satis` command will always set the path in the resulting file. This overrides any value, even if one is present in the template being used. As a result, the user is always required to supply the option.

Ideally the user should not be required to supply the option, but be able to provide one in the template. In the case that neither a value is provided in the template or as an option, the default `http://localhost/satis/` should be used.

This PR also cleans up some trailing white space that was present in the command source.