### PR TITLE
Use default pram value for --homepage options default value.

### DIFF
--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -39,7 +39,7 @@ class GitlabToConfigCommand extends Command {
             ->addOption('template', null, InputOption::VALUE_REQUIRED, 'template satis.json extended with gitlab repositories', $templatePath)
 
             // simple customization
-            ->addOption('homepage', null, InputOption::VALUE_REQUIRED, 'satis homepage', 'http://localhost/satis/')
+            ->addOption('homepage', null, InputOption::VALUE_REQUIRED, 'satis homepage', static::HOMEPAGE_DEFAULT)
             ->addOption('archive', null, InputOption::VALUE_NONE, 'enable archive mirroring')
 
             ->addOption('no-token', null, InputOption::VALUE_NONE, 'disable token writing in output configuration')


### PR DESCRIPTION
One more pr.

When opening #9, I refactored my commit and dropped a change. The command's option should use the new class `const` instead of the hard coded value. Without this it still uses the localhost value by default.