### PR TITLE
Add --ignore option

### DIFF
--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -47,6 +47,9 @@ class GitlabToConfigCommand extends Command {
             // output configuration
             ->addOption('output', 'O', InputOption::VALUE_REQUIRED, 'output config file', 'satis.json')
 
+            // ignored projects/namespaces
+            ->addOption('ignore', 'i', InputOption::VALUE_REQUIRED, 'array of projects/namespaces to ignore', null)
+
         ;
     }
 
@@ -58,6 +61,7 @@ class GitlabToConfigCommand extends Command {
         $gitlabAuthToken = $input->getArgument('gitlab-token');
         $outputFile = $input->getOption('output');
         $projectFilter = $input->getOption('projectFilter');
+        $ignore = $input->getOption('ignore');
 
         /*
          * load template satis.json file
@@ -122,10 +126,19 @@ class GitlabToConfigCommand extends Command {
             $output->writeln(sprintf("<info>Applying project filter %s...</info>", $projectFilter));
         }
 
+        if ($ignore !== null) {
+            $output->writeln(sprintf("<info>Ignore projects/namespaces by expression %s...</info>", $ignore));
+        }
+
         for ($page = 1; $page <= self::MAX_PAGES; $page++) {
             $projectCriteria['page'] = $page;
 
             $projects = $client->projects()->all($projectCriteria);
+
+            if ($ignore !== null) {
+                $projects = $this->removeIgnored($projects, $ignore, $output);
+            }
+
             if ( empty($projects) ){
                 break;
             }
@@ -188,6 +201,27 @@ class GitlabToConfigCommand extends Command {
         ),$verbosity);
     }
 
+    /**
+     * Ignore projects set in --ignore
+     * @param $projects
+     * @param $ignore
+     * @see Build your regex to ignore https://www.phpliveregex.com/
+     */
+    protected function removeIgnored($projects, $ignore, OutputInterface $output) {
+
+        $noIgnored = [];
+        foreach($projects as $project) {
+            preg_match("/$ignore/", $project['path_with_namespace'], $ignored);
+            if(empty($ignored)) {
+                $noIgnored[] = $project;
+            } else {
+                $output->writeln(sprintf("<info>Ignoring Project %s </info>", $project['path_with_namespace']));
+            }
+        }
+
+        return $noIgnored;
+
+    }
 
     /**
      * Create gitlab client

--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -208,7 +208,7 @@ class GitlabToConfigCommand extends Command {
      * @see Build your regex to ignore https://www.phpliveregex.com/
      */
     protected function removeIgnored($projects, $ignore, OutputInterface $output) {
-        $noIgnored = [];
+        $notIgnored = [];
         foreach($projects as $project) {
             preg_match("/$ignore/", $project['path_with_namespace'], $ignored);
             if(empty($ignored)) {

--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -208,19 +208,16 @@ class GitlabToConfigCommand extends Command {
      * @see Build your regex to ignore https://www.phpliveregex.com/
      */
     protected function removeIgnored($projects, $ignore, OutputInterface $output) {
-
         $noIgnored = [];
         foreach($projects as $project) {
             preg_match("/$ignore/", $project['path_with_namespace'], $ignored);
             if(empty($ignored)) {
-                $noIgnored[] = $project;
+                $notIgnored[] = $project;
             } else {
                 $output->writeln(sprintf("<info>Ignoring Project %s </info>", $project['path_with_namespace']));
             }
         }
-
-        return $noIgnored;
-
+        return $notIgnored;
     }
 
     /**


### PR DESCRIPTION
#16 Add option to ignore entire namespaces or projects

example:
```
--ignore="(^phpstorm|^typo3\/library)"
```