### PR TITLE
Add filter for Gitlab Namespace.

### DIFF
--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -64,7 +64,7 @@ class GitlabToConfigCommand extends Command {
             ->addOption('ignore', 'i', InputOption::VALUE_REQUIRED, 'ignore project according to a regexp, for ex : "(^phpstorm|^typo3\/library)"', null)
             ->addOption('include-if-has-file',null,InputOption::VALUE_REQUIRED, 'include in satis config if project contains a given file, for ex : ".satisinclude"', null)
             ->addOption('project-type',null,InputOption::VALUE_REQUIRED, 'include in satis config if project is of a specified type, for ex : "library"', null)
-            ->addOption('gitlab-groups',null,InputOption::VALUE_REQUIRED, 'include in satis config if gitlab project namespace is in the list, for ex : "2,Diaspora"', null)
+            ->addOption('gitlab-namespace',null,InputOption::VALUE_REQUIRED, 'include in satis config if gitlab project namespace is in the list, for ex : "2,Diaspora"', null)
             /* 
              * satis config generation options 
              */
@@ -134,9 +134,9 @@ class GitlabToConfigCommand extends Command {
             ));
         }
         /* project-type option */
-        if ( ! empty($input->getOption('gitlab-groups')) ){
+        if ( ! empty($input->getOption('gitlab-namespace')) ){
             $filterCollection->addFilter(new GitlabNamespaceFilter(
-                $input->getOption('gitlab-groups')
+                $input->getOption('gitlab-namespace')
             ));
         }
 

--- a/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
+++ b/src/MBO/SatisGitlab/Command/GitlabToConfigCommand.php
@@ -20,6 +20,7 @@ use MBO\SatisGitlab\Git\ClientOptions;
 use MBO\SatisGitlab\Git\GitlabProject;
 use MBO\SatisGitlab\Filter\FilterCollection;
 
+use MBO\SatisGitlab\Filter\GitlabNamespaceFilter;
 use MBO\SatisGitlab\Filter\IgnoreRegexpFilter;
 use MBO\SatisGitlab\Filter\IncludeIfHasFileFilter;
 use MBO\SatisGitlab\Filter\ProjectTypeFilter;
@@ -63,6 +64,7 @@ class GitlabToConfigCommand extends Command {
             ->addOption('ignore', 'i', InputOption::VALUE_REQUIRED, 'ignore project according to a regexp, for ex : "(^phpstorm|^typo3\/library)"', null)
             ->addOption('include-if-has-file',null,InputOption::VALUE_REQUIRED, 'include in satis config if project contains a given file, for ex : ".satisinclude"', null)
             ->addOption('project-type',null,InputOption::VALUE_REQUIRED, 'include in satis config if project is of a specified type, for ex : "library"', null)
+            ->addOption('gitlab-groups',null,InputOption::VALUE_REQUIRED, 'include in satis config if gitlab project namespace is in the list, for ex : "2,Diaspora"', null)
             /* 
              * satis config generation options 
              */
@@ -129,6 +131,12 @@ class GitlabToConfigCommand extends Command {
                 $input->getOption('project-type'),
                 $client,
                 $logger
+            ));
+        }
+        /* project-type option */
+        if ( ! empty($input->getOption('gitlab-groups')) ){
+            $filterCollection->addFilter(new GitlabNamespaceFilter(
+                $input->getOption('gitlab-groups')
             ));
         }
 

--- a/src/MBO/SatisGitlab/Filter/GitlabNamespaceFilter.php
+++ b/src/MBO/SatisGitlab/Filter/GitlabNamespaceFilter.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MBO\SatisGitlab\Filter;
+
+use MBO\SatisGitlab\Git\ProjectInterface;
+use MBO\SatisGitlab\Git\ClientInterface as GitClientInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Filter projects based on GitLab project namespace name or id.
+ */
+class GitlabNamespaceFilter implements ProjectFilterInterface {
+    /**
+     * @var string[]
+     */
+    protected $groups;
+
+    /**
+     * @var GitClientInterface
+     */
+    protected $gitClient;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * GitlabNamespaceFilter constructor.
+     *
+     * @param string $type
+     * @param GitClientInterface $gitClient
+     * @param LoggerInterface $logger
+     */
+    public function __construct($groups)
+    {
+        assert(!empty($groups));
+        $this->groups = explode(',',strtolower($groups));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAccepted(ProjectInterface $project)
+    {
+        $project_info = $project->getRawMetadata();
+        if (isset($project_info['namespace'])) {
+            
+            // Extra data from namespace to patch on.
+            $valid_keys = [
+                'name' => 'name',
+                'id' => 'id',
+            ];
+            $namespace_info = array_intersect_key($project_info['namespace'], $valid_keys);
+            $namespace_info = array_map('strtolower', $namespace_info);
+            
+            if (!empty($namespace_info) && !empty(array_intersect($namespace_info, $this->groups))) {
+                // Accept any package with a permitted namespace name or id.
+                return TRUE;
+            }
+        }
+        return FALSE;
+    }
+}


### PR DESCRIPTION
For our deployment of this, we found it helpful to filter by the namespaces associated with the project. The new command filters by a list of namespace ids or names.

It can be used as follows
`--gitlab-namespace=4,Diaspora`