### PR TITLE
fix: use php binary from env

### DIFF
--- a/bin/satis-gitlab
+++ b/bin/satis-gitlab
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 /*


### PR DESCRIPTION
Instead of using a fixed absolute path to the PHP binary, this fix will search for PHP in the current environment, i.e. searching the PATH variable using the first php binary found. This is handy if the system php binary is old/outdated and a newer is installed in a different location, e.g. /usr/local/bin or $HOME/bin.